### PR TITLE
exp/html changed to code.google.com/p/go.net/html

### DIFF
--- a/htmlutil/htmlutil.go
+++ b/htmlutil/htmlutil.go
@@ -2,7 +2,7 @@
 package htmlutil
 
 import "bytes"
-import "exp/html"
+import "code.google.com/p/go.net/html"
 import "fmt"
 import "io"
 import "os"


### PR DESCRIPTION
Hi brother! :)

exp/html has been moved, further information [here](https://groups.google.com/forum/#!topic/golang-nuts/Qq5hTQyPuLg/discussion).
